### PR TITLE
Allow tracking opens

### DIFF
--- a/src/Postmark/Message.php
+++ b/src/Postmark/Message.php
@@ -22,6 +22,7 @@ class Message implements JsonSerializable {
     private $htmlBody;
     private $textBody;
     private $replyTo;
+    private $trackOpens;
     private $headers = array();
     private $attachments = array();
 
@@ -80,6 +81,11 @@ class Message implements JsonSerializable {
         $this->from = $this->createAddress($address, $name);
     }
 
+    public function trackOpens()
+    {
+        $this->trackOpens = true;
+    }
+
     private function createAddress($address, $name = null) {
         if (!is_null($name)) {
             if ( 1 === preg_match('/^[A-z0-9 ]*$/', $name)) {
@@ -103,6 +109,7 @@ class Message implements JsonSerializable {
             'ReplyTo'  => $this->replyTo,
             'Headers'  => $this->headers,
             'Attachments' => $this->attachments,
+            'TrackOpens' => $this->trackOpens,
         ];
         return array_filter($json);
     }

--- a/tests/Postmark/MessageTest.php
+++ b/tests/Postmark/MessageTest.php
@@ -70,6 +70,16 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('{"From":"\"Last, Foo\" <foo@example.org>"}', json_encode($message));
     }
 
+    /**
+     * @covers Postmark\Message::trackOpens
+     */
+    public function testTrackOpens()
+    {
+        $message = new Message();
+        $message->trackOpens();
+        $this->assertEquals('{"TrackOpens":true}', json_encode($message));
+    }
+
     public function testPostmarkExamples()
     {
         $example1 = '{"From":"sender@example.com","To":"receiver@example.com","Cc":"copied@example.com","Bcc":"blank-copied@example.com","Subject":"Test","Tag":"Invitation","HtmlBody":"<b>Hello</b>","TextBody":"Hello","ReplyTo":"reply@example.com","Headers":[{"Name":"CUSTOM-HEADER","Value":"value"}]}';


### PR DESCRIPTION
Per the [Postmark API](http://developer.postmarkapp.com/developer-send-api.html), you can configure whether to track email opens using:

``` JSON
{
  "TrackOpens": true
}
```
